### PR TITLE
Upgrade CentOS 6.8

### DIFF
--- a/Prepare-Iso.ps1
+++ b/Prepare-Iso.ps1
@@ -5,7 +5,7 @@
 
 [CmdletBinding()]
 Param (
-  [Parameter()] [string] $OsVersion = "6.6"
+  [Parameter()] [string] $OsVersion = "6.8"
   , [Parameter()] [string] $OsArchitecture = "x86_64"
   , [Parameter()] [string] $OsMirror = "http://gd.tuwien.ac.at/opsys/linux/centos"
 )
@@ -48,7 +48,7 @@ Copy-Item -Force -Path ks.cfg -Destination ${IsoWorkDir}
 
 # repack iso
 Write-Verbose "repackage installation image"
-mkisofs --verbose -r -N -L -d -J -T -b isolinux/isolinux.bin -c isolinux\boot.cat -no-emul-boot -V centos-netinstall-ks -boot-load-size 4 -boot-info-table -o ${InstallIso} ${IsoWorkDir}
+mkisofs --verbose -r -N -allow-leading-dots -d -J -T -b isolinux/isolinux.bin -c isolinux\boot.cat -no-emul-boot -V centos-netinstall-ks -boot-load-size 4 -boot-info-table -o ${InstallIso} ${IsoWorkDir}
 
 # clean up
 Remove-Item -Recurse -Path ${IsoWorkDir}

--- a/isolinux.cfg
+++ b/isolinux.cfg
@@ -5,7 +5,7 @@ timeout 0
 display boot.msg
 
 menu background splash.jpg
-menu title Welcome to CentOS 6.6!
+menu title Welcome to CentOS 6.8!
 menu color border 0 #ffffffff #00000000
 menu color sel 7 #ffffffff #ff000000
 menu color title 0 #ffffffff #00000000
@@ -39,4 +39,3 @@ label memtest86
   menu label ^Memory test
   kernel memtest
   append -
-

--- a/ks.cfg
+++ b/ks.cfg
@@ -6,7 +6,7 @@ install
 cmdline
 skipx
 shutdown
-url --url=http://ftp.tugraz.at/mirror/centos/6.6/os/x86_64
+url --url=http://ftp.tugraz.at/mirror/centos/6.8/os/x86_64
 lang en_US.UTF-8
 timezone --utc Europe/Berlin
 keyboard uk
@@ -28,7 +28,7 @@ volgroup vg_dev --pesize=4096 pv.008002
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_dev --grow --size=1024 --maxsize=51200
 logvol swap --name=lv_swap --vgname=vg_dev --grow --size=1984 --maxsize=1984
 
-repo --name="CentOS"  --baseurl=http://ftp.tugraz.at/mirror/centos/6.6/os/x86_64 --cost=100
+repo --name="CentOS"  --baseurl=http://ftp.tugraz.at/mirror/centos/6.8/os/x86_64 --cost=100
 services --enabled hypervkvpd
 
 %packages


### PR DESCRIPTION
Aside from replacing `6.6` to `6.8` everywhere, I also had to replace mkisofs' `-L` key with `-allow-leading-dots` because it seems to be a modern replacement according to [`man mkisofs`](http://linux.die.net/man/8/mkisofs). I used [this](https://chocolatey.org/packages/cdrtfe) distribution of cdrtools to get mkisofs.

I can confirm that I've been able to download and deploy CentOS 6.8 using these scripts, but I haven't been lucky enough to create a functional Vagrant box from it because of https://github.com/mitchellh/vagrant/issues/6102. I'll try to fix that problem in Vagrant itself.

Closes #1.
